### PR TITLE
Make pytest watch modules configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ VENV = venv
 PIP = $(VENV)/bin/pip
 PYTHON = $(VENV)/bin/python
 
+PYTEST_WATCH_MODULES = tests/unit_test
+
 
 venv-clean:
 	@if [ -d "$(VENV)" ]; then \
@@ -50,7 +52,10 @@ dev-unittest:
 dev-test: dev-lint dev-unittest
 
 dev-watch:
-	$(PYTHON) -m pytest_watcher tests/unit_test
+	$(PYTHON) -m pytest_watcher \
+		--runner=$(VENV)/bin/python \
+		. \
+		-m pytest $(PYTEST_WATCH_MODULES)
 
 
 dev-start:


### PR DESCRIPTION
This allows to select the particular test to run by specifying `PYTEST_WATCH_MODULES`, e.g.

```bash
make dev-watch PYTEST_WATCH_MODULES=tests/unit_test/api_router_test.py
```

It also fixes the directory to watch (which was previously just the tests)